### PR TITLE
Add Tailwind CSS to React client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ npm run build
 
 Each app can be run individually using `npm --workspace <path> run dev`.
 
+## Styling with Tailwind CSS
+
+The React client comes preconfigured with [Tailwind CSS](https://tailwindcss.com).
+Global styles live in `apps/web/src/index.css` and are imported in
+`apps/web/src/main.tsx`. Feel free to customize the Tailwind configuration in
+`apps/web/tailwind.config.cjs`.
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and adjust the values for your local setup.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Web</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="min-h-screen bg-gray-100">
+    <div id="root" class="flex items-center justify-center"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,9 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.0.4",
-    "vite": "^4.5.0"
+    "vite": "^4.5.0",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
   }
 }

--- a/apps/web/postcss.config.cjs
+++ b/apps/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './index.css';
 
-const App = () => <h1>Hello from React</h1>;
+const App = () => (
+  <div className="text-center py-10">
+    <h1 className="text-2xl font-bold text-blue-600">Hello from React</h1>
+    <p className="mt-4 text-gray-700">Tailwind is configured!</p>
+  </div>
+);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/apps/web/tailwind.config.cjs
+++ b/apps/web/tailwind.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind CSS for the `web` app
- add base Tailwind styles
- update React entry to use Tailwind classes
- tweak `index.html` layout
- document styling setup in README

## Testing
- `npm run build` *(fails: npm-run-all not found)*